### PR TITLE
#8

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -74,7 +74,7 @@ Router.post("/email/signup/", (req, res) => {
       if (password == confirmPassword) {
         if (password.length >= 7) {
           if (!emailExists) {
-            let accountId = "acc_"+Buffer.from(nodeName+"*email:"+email.substring(0, 7)).toString('base64url');
+            let accountId = "acc_"+Buffer.from(nodeName + (nodeName.includes("*email:") ? "" : "*email:") + email.substring(0, 7)).toString('base64url');
             [salt, password] = files.hash(password).split(":");
 
             account.password = password;
@@ -306,7 +306,7 @@ Router.post("/discord/", (req, res) => {
         writeAccount(account.accountId, "discord:"+username, account.email, account.servers, 0, account.freeServers, account.lastSignin, account.token, account.salt, account.password, account.resetAttempts);
         res.status(200).send(response);
       } else {
-        let accountId = "acc_"+Buffer.from(nodeName+"*email:"+email.substring(0, 7)).toString('base64url');
+        let accountId = "acc_"+Buffer.from(nodeName + (nodeName.includes("*email:") ? "" : "*email:") + email.substring(0, 7)).toString('base64url');
 
         account.accountId = accountId;
         account.token = uuidv4();


### PR DESCRIPTION
Before appending "email:", we check if the nodeName already contains it
If it does, we don't append it again
If it doesn't, we append it as before

This will prevent the double "email:" issue while maintaining the expected format for account IDs.

Will need to do further testing but seems fine so far.