### PR TITLE
Fixed inaccurate expiration checks, simplified logs

### DIFF
--- a/routes/info.js
+++ b/routes/info.js
@@ -70,12 +70,12 @@ router.get(`/servers`, function (req, res) {
 
         for (let sub of subscriptionsJson) {
       
-          try {
+
             if (sub.owner == req.headers.username + ".json") {
                         
             for (let item of sub.subscriptions) {
                 
-              if (item.plan.active) {
+              if (item.status == "active") {
                 hasValidSubscription = true;
           
               } else {
@@ -86,10 +86,7 @@ router.get(`/servers`, function (req, res) {
             }
           } 
       
-          } catch (e) { 
-            console.log("Error processing subscription for " + req.headers.username + ": " + e);
-                hasValidSubscription = true;
-          } 
+          
         }
         console.log("hasValidSubscription: " + hasValidSubscription);
       }

--- a/routes/info.js
+++ b/routes/info.js
@@ -66,6 +66,7 @@ router.get(`/servers`, function (req, res) {
         if (providerMode) {
           hasValidSubscription = false;
                   let subscriptionsJson = readJSON(`logs/subscriptions.json`);
+                  let latestStartDate = 0;
 
 
         for (let sub of subscriptionsJson) {
@@ -74,7 +75,10 @@ router.get(`/servers`, function (req, res) {
             if (sub.owner == req.headers.username + ".json") {
                         
             for (let item of sub.subscriptions) {
-                
+
+              if (item.start_date > latestStartDate) {
+                latestStartDate = item.start_date;
+              }
               if (item.status == "active") {
                 hasValidSubscription = true;
           
@@ -89,6 +93,10 @@ router.get(`/servers`, function (req, res) {
           
         }
         console.log("hasValidSubscription: " + hasValidSubscription);
+        //if the start date is from the past 24 hours, set hasValidSubscription to true
+        if (latestStartDate > 0 && latestStartDate < Date.now() - 86400000) {
+          hasValidSubscription = true;
+        }
       }
         if (!hasValidSubscription) {
           account.servers[i] = account.servers[i] + ":no valid subscription:" + resetDate;

--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -721,7 +721,7 @@ router.post(`/new/:id`, function (req, res) {
                               subscriptionsJson
                             );
                           } catch (e) {
-
+                            console.log("error writing subscriptions.json: " + e);
                           }
                           if (
                             em !== "noemail" &&

--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -695,6 +695,34 @@ router.post(`/new/:id`, function (req, res) {
                             fullServers
                         );
                         if (canCreateServer) {
+                          try {
+                            //read subscriptions.json
+                            let subscriptionsJson = readJSON(
+                              "logs/subscriptions.json"
+                            );
+                            //append basic info so it isn't marked as expired
+                            subscriptionsJson.push({
+                              serverId: id,
+                              owner: email,
+                              email: account.email,
+                              storage: 0,
+                              subscriptions: [
+                                {
+                                  status: "active",
+                                  ended_at: null,
+                                  current_period_end: Math.floor(Date.now() / 1000) + 86400,
+                                  start_date: Math.floor(Date.now() / 1000),
+                                }
+                              ]
+                            });
+                            //write subscriptions.json  
+                            writeJSON(
+                              "logs/subscriptions.json",
+                              subscriptionsJson
+                            );
+                          } catch (e) {
+
+                          }
                           if (
                             em !== "noemail" &&
                             req.body.software !== "undefined" &&

--- a/scripts/files.js
+++ b/scripts/files.js
@@ -69,7 +69,7 @@ function folderSizeRecursive(directoryPath) {
       bytes += fs.statSync(curPath).size;
     }
   });
-  console.log("folder size: " + bytes)
+
   return bytes;
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -338,7 +338,7 @@ try {
         );
         console.log("Subscriptions checked and logged.");
         //stop any servers with no active subscriptions
-        /*for (let i in data) {
+        for (let i in data) {
 
           if (data[i].subscriptions == undefined) {
             console.log("No subscriptions found for " + data[i].serverId);
@@ -402,7 +402,7 @@ try {
             console.log("Server " + data[i].serverId + " has an active subscription.");
           }
           
-        }*/
+        }
       }
       , 1000 * 60);
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -359,6 +359,7 @@ try {
           console.log("Checking server " + data[i].serverId);
           let isActiveSubscription = false;
           let latestEndDate = 0;
+          let latestStartDate = 0;
           if (data[i].subscriptions != undefined) {
             for (let j in data[i].subscriptions) {
               if (
@@ -370,8 +371,16 @@ try {
                 if (data[i].subscriptions[j].ended_at > latestEndDate) {
                   latestEndDate = data[i].subscriptions[j].ended_at;
                 }
+                if (data[i].subscriptions[j].start_date > latestStartDate) {
+                  latestStartDate = data[i].subscriptions[j].start_date;
+                }
               }
             }
+          }
+          //if latestStart date was within the past 24 hours, then well mark it as an active subscription
+          //this is because the subscriptions.json file may not have been refreshed yet
+          if (latestStartDate > Date.now() - 1000 * 60 * 60 * 24) {
+            isActiveSubscription = true;
           }
           if (!isActiveSubscription) {
             console.log("Stopping server " + data[i].serverId + " due to no active subscriptions.");

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -187,7 +187,14 @@ try {
                                               } else {
                                                  customerSubscriptions = subscriptions.data;
                                                 for (let i in customerSubscriptions) {
-                                                  subscriptionsA.push(customerSubscriptions[i]);
+                                                                                                   subItem = {};
+                                                 subItem.status = customerSubscriptions[i].status;
+                                                 subItem.ended_at = customerSubscriptions[i].ended_at;
+                                                 subItem.current_period_end = customerSubscriptions[i].current_period_end;
+                                                 subItem.start_date = customerSubscriptions[i].start_date;
+                                              
+                                                  subscriptionsA.push(subItem);
+                                                  
                                                 }
                                               }
                                             }
@@ -279,7 +286,13 @@ try {
                                               } else {
                                                  customerSubscriptions = subscriptions.data;
                                                 for (let i in customerSubscriptions) {
-                                                  subscriptionsA.push(customerSubscriptions[i]);
+                                                                                                   subItem = {};
+                                                 subItem.status = customerSubscriptions[i].status;
+                                                 subItem.ended_at = customerSubscriptions[i].ended_at;
+                                                 subItem.current_period_end = customerSubscriptions[i].current_period_end;
+                                                 subItem.start_date = customerSubscriptions[i].start_date;
+                                              
+                                                  subscriptionsA.push(subItem);
                                                   
                                                 }
                                               }
@@ -325,7 +338,7 @@ try {
         );
         console.log("Subscriptions checked and logged.");
         //stop any servers with no active subscriptions
-        for (let i in data) {
+        /*for (let i in data) {
 
           if (data[i].subscriptions == undefined) {
             console.log("No subscriptions found for " + data[i].serverId);
@@ -389,7 +402,7 @@ try {
             console.log("Server " + data[i].serverId + " has an active subscription.");
           }
           
-        }
+        }*/
       }
       , 1000 * 60);
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -326,6 +326,11 @@ try {
         console.log("Subscriptions checked and logged.");
         //stop any servers with no active subscriptions
         for (let i in data) {
+
+          if (data[i].subscriptions == undefined) {
+            console.log("No subscriptions found for " + data[i].serverId);
+            continue;
+          }
           let adminServer = false;
           try {
             let serverJson = readJSON(`servers/${data[i].serverId}/server.json`);


### PR DESCRIPTION
**Fixed servers route incorrectly stating a subscription is valid**
Previously, the route checked the `plan` object which would always return true as long as the plan still exists.

**Redacted unnecessary data from subscriptions.json log**
To make the file easier to read, only attributes read by quartz are kept.

**Immunity from expiration feature for new servers**
Previously, the logs would try to refresh whenever a server was created to fix this problem, but this is highly inefficient and buggy. Now, quartz marks it as valid if the subscription started under 24 hours ago.