### PR TITLE
fixed noemail.json bug not being completely fixed

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -133,7 +133,7 @@ try {
               const accountId = json.accountId;
               fs.readdirSync("accounts").forEach((file) => {
                 const account = readJSON(`accounts/${file}`);
-                if (account.accountId == accountId) {
+                if (account.accountId == accountId && file != "noemail.json") {
                   owner = file;
                   if (!file.includes("email:")) email = account.email;
                   else email = file.split("email:")[1].split(".json")[0];
@@ -227,7 +227,7 @@ try {
             fs.readdirSync("accounts").forEach((file) => {
               try {
                 let account = readJSON(`accounts/${file}`);
-  
+                console.log("Checking account " + file);
                 if (
                   account.servers.includes(serverId) ||
                   account.servers.includes(parseInt(serverId))


### PR DESCRIPTION
This issue from #11 wasn't patched in all circumstances

Noemail issue
Previously, quartz would add the "noemail" file (used for non-provider mode) to subscriptions logs, leading a server to be incorrectly marked as expired.