### PR TITLE
Player List feature

### DIFF
--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -1524,9 +1524,17 @@ router.get("/:id/players", function (req, res) {
   let token = req.headers.token;
   let account = readJSON("accounts/" + email + ".json");
   if (utils.hasAccess(token, account, req.params.id)) {
-    let players = f.getPlayerList(req.params.id);
-    if (players) {
-      res.status(200).json(players);
+    let playersOnline = f.getPlayerList(req.params.id);
+    if (playersOnline) {
+      let allPlayers = [];
+      let folder = fs.readdirSync(`servers/${req.params.id}/world/playerdata`);
+      folder.forEach((file) => {
+        if (file.endsWith(".dat") || file.endsWith(".dat_old")) {
+          let uuid = file.replace(".dat", "").replace(".dat_old", "");
+          allPlayers.push(uuid);
+        }
+      });
+      res.status(200).json({ playersOnline, allPlayers });
     }
   } else {
     res.status(401).json({ msg: "Invalid credentials." });

--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -1529,8 +1529,8 @@ router.get("/:id/players", function (req, res) {
       let allPlayers = [];
       let folder = fs.readdirSync(`servers/${req.params.id}/world/playerdata`);
       folder.forEach((file) => {
-        if (file.endsWith(".dat") || file.endsWith(".dat_old")) {
-          let uuid = file.replace(".dat", "").replace(".dat_old", "");
+        if (file.endsWith(".dat")) {
+          let uuid = file.replace(".dat", "");
           allPlayers.push(uuid);
         }
       });

--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -1526,14 +1526,20 @@ router.get("/:id/players", function (req, res) {
   if (utils.hasAccess(token, account, req.params.id)) {
     let playersOnline = f.getPlayerList(req.params.id);
     if (playersOnline) {
+      let usercache = readJSON("servers/" + req.params.id + "/usercache.json");
       let allPlayers = [];
-      let folder = fs.readdirSync(`servers/${req.params.id}/world/playerdata`);
-      folder.forEach((file) => {
-        if (file.endsWith(".dat")) {
-          let uuid = file.replace(".dat", "");
-          allPlayers.push(uuid);
+      if (usercache) {
+        for (let i = 0; i < usercache.length; i++) {
+          let player = usercache[i];
+          if (player.name && player.uuid) {
+            allPlayers.push({
+              name: player.name,
+              uuid: player.uuid,
+        
+            });
+          }
         }
-      });
+      }
       res.status(200).json({ playersOnline, allPlayers });
     }
   } else {

--- a/routes/server/index.js
+++ b/routes/server/index.js
@@ -1519,6 +1519,20 @@ router.get("/:id/backup/:timestamp", function (req, res) {
   }
 });
 
+router.get("/:id/players", function (req, res) {
+  let email = req.headers.username;
+  let token = req.headers.token;
+  let account = readJSON("accounts/" + email + ".json");
+  if (utils.hasAccess(token, account, req.params.id)) {
+    let players = f.getPlayerList(req.params.id);
+    if (players) {
+      res.status(200).json(players);
+    }
+  } else {
+    res.status(401).json({ msg: "Invalid credentials." });
+  }
+});
+
 
 
 module.exports = router;

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1223,9 +1223,15 @@ function readTerminal(id) {
 } 
  if (ret.includes("left the game")) {
     let name = ret.split("left the game")[0].split(" ")[ret.split("left the game")[0].split(" ").length - 1];
-    players[id] = players[id] || [];
-    players[id] = players[id].filter((p) => p.name != name);
+    let uuid = players[id].find((p) => p.name === name)?.uuid;
+    if (uuid) {
+      players[id] = players[id].filter((p) => p.uuid !== uuid);
+    }
   }
+
+  ret = files.simplifyTerminal(ret, server.software);
+
+  return ret;
 }
 
 function writeTerminal(id, cmd) {

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1224,7 +1224,8 @@ function readTerminal(id) {
   
 } 
  if (ret.includes("left the game")) {
-    let name = ret.split("left the game")[0].split(" ")[ret.split("left the game")[0].split(" ").length - 1];
+    let name = ret.split(" left the game")[0].split(": ")[ret.split(" left the game")[0].split(": ").length - 1];
+
     let uuid = players[id].find((p) => p.name === name)?.uuid;
     if (uuid) {
       players[id] = players[id].filter((p) => p.uuid !== uuid);

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1189,7 +1189,7 @@ function readTerminal(id) {
   let server = readJSON("servers/" + id + "/server.json");
   let ret = terminalOutput[id];
 
-  console.log(players[id]);
+
 
   //detect java player join
   if (ret.includes("UUID of player")) {
@@ -1211,7 +1211,7 @@ function readTerminal(id) {
   } 
    if (ret.includes(" (UUID: ")) {
   
-    let name = "."+ret.split(" (UUID: ")[0].split(".")[0].split(" ")[ret.split(" (UUID: ")[0].split(".")[0].split(" ").length - 1];
+    let name = "."+ret.split(" joined (UUID: ")[0].split(".")[ret.split(" (UUID: ")[0].split(".").length - 1];
     let uuid = ret.split(" (UUID: ")[1].split(")")[0];
     
     players[id] = players[id] || [];  

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -165,7 +165,7 @@ function run(
     let server = readJSON("servers/" + id + "/server.json");
     let out = [];
     states[id] = "starting";
-
+    players[id] = [];
     
 
     // i isNew is undefined, set it to true
@@ -1188,6 +1188,8 @@ function kill(id) {
 function readTerminal(id) {
   let server = readJSON("servers/" + id + "/server.json");
   let ret = terminalOutput[id];
+
+  console.log(players[id]);
 
   //detect java player join
   if (ret.includes("UUID of player")) {

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -13,6 +13,8 @@ const writeJSON = require("./utils.js").writeJSON;
 let terminalOutput = [];
 let terminalInput = "";
 
+let players = [];
+
 const portOffset = 10000; 
 
 let amountOfThreads = 16;
@@ -1193,74 +1195,37 @@ function readTerminal(id) {
     let name = ret.split("UUID of player ")[1].split(" is ")[0];
     let uuid = ret.split("UUID of player ")[1].split(" is ")[1].split("\n")[0];
 
-    let playersJsonCurrent = undefined;
-    if (fs.existsSync("servers/" + id + "/players.json")) {
-      playersJsonCurrent = readJSON("servers/" + id + "/players.json");
-    }
-    let playersJsonNew = [];
-    if (playersJsonCurrent != undefined) {
-      playersJsonNew = playersJsonCurrent;
-      //if player isnt already in the array, add them
-      if (!playersJsonNew.some((p) => p.uuid === uuid)) {
-        playersJsonNew.push({
+ 
+    players[id] = players[id] || [];
+    if (!players[id].some((p) => p.uuid === uuid)) {
+      players[id].push({
       name: name,
       uuid: uuid,
-
-    });
-  }
-    } else {
-      playersJsonNew.push({
-      name: name,
-      uuid: uuid,
-  
     });
     }
     
-    writeJSON("servers/" + id + "/players.json", playersJsonNew);
+
     //detect bedrock player join
   } 
    if (ret.includes(" (UUID: ")) {
-    //unix timestamp
-    let timestamp = new Date().toLocaleTimeString();
-    let name = ret.split(" (UUID: ")[0];
-    let uuid = ret.split(" (UUID: ")[1].split(")")[0];
-    let playersJsonCurrent = undefined;
-    if (fs.existsSync("servers/" + id + "/players.json")) {
-      playersJsonCurrent = readJSON("servers/" + id + "/players.json");
-    }
-    let playersJsonNew = [];
-    if (playersJsonCurrent != undefined) {
-      playersJsonNew = playersJsonCurrent;
-    }
-    playersJsonNew.push({
-      name: name,
-      uuid: uuid,
-     
-    });
-    writeJSON("servers/" + id + "/players.json", playersJsonNew);
   
-
+    let name = "."+ret.split(" (UUID: ")[0].split(".")[0].split(" ")[ret.split(" (UUID: ")[0].split(".")[0].split(" ").length - 1];
+    let uuid = ret.split(" (UUID: ")[1].split(")")[0];
+    
+    players[id] = players[id] || [];  
+    if (!players[id].some((p) => p.uuid === uuid)) {
+      players[id].push({
+        name: name,
+        uuid: uuid,
+      });
+    }
   
 } 
  if (ret.includes("left the game")) {
-    let playersJsonCurrent = undefined;
-    if (fs.existsSync("servers/" + id + "/players.json")) {
-      playersJsonCurrent = readJSON("servers/" + id + "/players.json");
-    }
-    let playersJsonNew = [];
-    if (playersJsonCurrent != undefined) {
-      playersJsonNew = playersJsonCurrent;
-    }
-    let name = ret.split(" left the game")[0].split(" ")[ret.split(" left the game")[0].split(" ").length - 1];
-
-    //remove the player from the playersJsonNew array
-    playersJsonNew = playersJsonNew.filter((p) => p.name !== name);
-    writeJSON("servers/" + id + "/players.json", playersJsonNew);
+    let name = ret.split("left the game")[0].split(" ")[ret.split("left the game")[0].split(" ").length - 1];
+    players[id] = players[id] || [];
+    players[id] = players[id].filter((p) => p.name != name);
   }
-
-  ret = files.simplifyTerminal(ret, server.software);
-
-  return ret;
 }
 
 function writeTerminal(id, cmd) {

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1242,7 +1242,7 @@ function readTerminal(id) {
 
   
 } 
- if (ret.includes("has left the game")) {
+ if (ret.includes("left the game")) {
     let playersJsonCurrent = undefined;
     if (fs.existsSync("servers/" + id + "/players.json")) {
       playersJsonCurrent = readJSON("servers/" + id + "/players.json");
@@ -1251,8 +1251,8 @@ function readTerminal(id) {
     if (playersJsonCurrent != undefined) {
       playersJsonNew = playersJsonCurrent;
     }
-    let name = ret.split(" has left the game")[0].split(" ")[ret.split(" has left the game")[0].split(" ").length - 1];
-    console.log("removing player " + name + " from players.json");
+    let name = ret.split(" left the game")[0].split(" ")[ret.split(" left the game")[0].split(" ").length - 1];
+
     //remove the player from the playersJsonNew array
     playersJsonNew = playersJsonNew.filter((p) => p.name !== name);
     writeJSON("servers/" + id + "/players.json", playersJsonNew);

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1432,6 +1432,13 @@ function killObstructingProcess(id) {
   }
 }
 
+function getPlayerList(id) {
+  if (players[id] == undefined) {
+    players[id] = [];
+  }
+  return players[id];
+}
+
 module.exports = {
   run,
   stop,
@@ -1444,5 +1451,6 @@ module.exports = {
   getState,
   downloadModpack,
   killAsync,
-  getServersOnThreads
+  getServersOnThreads,
+  getPlayerList,
 };

--- a/scripts/mc.js
+++ b/scripts/mc.js
@@ -1211,7 +1211,7 @@ function readTerminal(id) {
   } 
    if (ret.includes(" (UUID: ")) {
   
-    let name = "."+ret.split(" joined (UUID: ")[0].split(".")[ret.split(" (UUID: ")[0].split(".").length - 1];
+    let name = "."+ret.split(" joined (UUID: ")[0].split(".")[ret.split(" joined (UUID: ")[0].split(".").length - 1];
     let uuid = ret.split(" (UUID: ")[1].split(")")[0];
     
     players[id] = players[id] || [];  
@@ -1436,6 +1436,7 @@ function getPlayerList(id) {
   if (players[id] == undefined) {
     players[id] = [];
   }
+  console.log(players[1])
   return players[id];
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9dbbbb08-f203-4c00-97a7-28e1bc33d41c)

**New Route**
The new `/server/:id/players` route returns a list of online players and of every player that has played on the server (via `usercache.json`)

**Why?**
This allows for a unique quality-life feature on our panel not common on other panels. In addition, users will (with more work) be able to easily manage bans, whitelists, and notice strange players joining without peering through logs.
